### PR TITLE
add duplexify requirement to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "debug": "^2.1.0",
+    "duplexify": "^3.2.0",
     "from2": "^1.2.0",
     "length-prefixed-stream": "^1.0.1",
     "lexicographic-integer": "^1.1.0",


### PR DESCRIPTION
This was needed to run example.js.
