### PR TITLE
valueEncoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,12 @@ Create a new log instance. Options include:
 
 ``` js
 {
-  id: 'a-globally-unique-peer-id'
+  id: 'a-globally-unique-peer-id',
+  valueEncoding: 'a levelup-style encoding property' // example: 'json'
 }
 ```
 
-#### `log.add(links, value, [cb])`
+#### `log.add(links, value, opts={}, [cb])`
 
 Add a new node to the graph. `links` should be an array of node keys that this node links to.
 If it doesn't link to any nodes use `null` or an empty array. `value` is the value that you want to store
@@ -78,15 +79,21 @@ log.add([link], value, function(err, node) {
 })
 ```
 
-#### `log.append(value, [cb])`
+Optionally supply an `opts.valueEncoding`.
+
+#### `log.append(value, opts={}, [cb])`
 
 Add a value that links all the current heads.
 
-#### `log.get(hash, cb)`
+Optionally supply an `opts.valueEncoding`.
+
+#### `log.get(hash, opts={}, cb)`
 
 Lookup a node by its hash. Returns a node similar to `.add` above.
 
-#### `log.heads(cb)`
+Optionally supply an `opts.valueEncoding`.
+
+#### `log.heads(opts={}, cb)`
 
 Get the heads of the graph as a list. A head is node that no other node
 links to.
@@ -112,6 +119,8 @@ headsStream.on('end', function() {
 })
 ```
 
+Optionally supply an `opts.valueEncoding`.
+
 #### `changesStream = log.createReadStream([options])`
 
 Tail the changes feed from the log. Everytime you add a node to the graph
@@ -129,9 +138,10 @@ Options include:
 
 ``` js
 {
-  since: changeNumber // only returns changes AFTER the number
-  live: false         // never close the change stream
-  tail: false         // since = lastChange
+  since: changeNumber     // only returns changes AFTER the number
+  live: false             // never close the change stream
+  tail: false             // since = lastChange
+  valueEncoding: 'binary'
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -76,8 +76,13 @@ Hyperlog.prototype.ready = function (cb) {
   })
 }
 
-Hyperlog.prototype.heads = function (cb) {
+Hyperlog.prototype.heads = function (opts, cb) {
   var self = this
+  if (!opts) opts = {}
+  if (typeof opts === 'function') {
+    cb = opts
+    opts = {}
+  }
 
   var rs = this.db.createValueStream({
     gt: HEADS,
@@ -86,20 +91,24 @@ Hyperlog.prototype.heads = function (cb) {
   })
 
   var format = through.obj(function (key, enc, cb) {
-    self.get(key, function (err, node) {
-      if (err) return cb(err)
-      node.value = encoder.decode(node.value, self.valueEncoding)
-      cb(null, node)
-    })
+    self.get(key, opts, cb)
   })
 
   return collect(pump(rs, format), cb)
 }
 
-Hyperlog.prototype.get = function (key, cb) {
+Hyperlog.prototype.get = function (key, opts, cb) {
+  if (!opts) opts = {}
+  if (typeof opts === 'function') {
+    cb = opts
+    opts = {}
+  }
+  var self = this
   this.db.get(NODES + key, {valueEncoding: 'binary'}, function (err, buf) {
     if (err) return cb(err)
-    cb(null, messages.Node.decode(buf))
+    var node = messages.Node.decode(buf)
+    node.value = encoder.decode(node.value, opts.valueEncoding || self.valueEncoding)
+    cb(null, node)
   })
 }
 
@@ -140,7 +149,7 @@ var add = function (dag, links, value, opts, cb) {
           })
         }
 
-        dag.get(node.key, function (_, clone) {
+        dag.get(node.key, { valueEncoding: 'binary' }, function (_, clone) {
           if (clone) return onclone(clone)
 
           var batch = []
@@ -195,7 +204,7 @@ var createLiveStream = function (dag, opts) {
 
     dag.db.get(CHANGES + lexint.pack(since + 1, 'hex'), function (err, hash) {
       if (err) return cb(err)
-      dag.get(hash, function (err, node) {
+      dag.get(hash, opts, function (err, node) {
         if (err) return cb(err)
         since = node.change
         if (limit !== -1) limit--
@@ -240,7 +249,7 @@ Hyperlog.prototype.createReadStream = function (opts) {
   })
 
   var get = function (key, enc, cb) {
-    self.get(key, cb)
+    self.get(key, opts, cb)
   }
 
   return pump(keys, through.obj(get))
@@ -249,10 +258,6 @@ Hyperlog.prototype.createReadStream = function (opts) {
 Hyperlog.prototype.replicate =
 Hyperlog.prototype.createReplicationStream = function (opts) {
   return replicate(this, opts)
-}
-
-Hyperlog.prototype.get = function (key, cb) {
-  this.db.get(NODES + key, {valueEncoding: messages.Node}, cb)
 }
 
 Hyperlog.prototype.add = function (links, value, opts, cb) {
@@ -267,23 +272,28 @@ Hyperlog.prototype.add = function (links, value, opts, cb) {
   this.ready(function () {
     add(self, links, value, opts, function (err, node) {
       if (err) return cb(err)
-      node.value = encoder.decode(node.value, self.valueEncoding)
+      node.value = encoder.decode(node.value, opts.valueEncoding || self.valueEncoding)
       cb(null, node)
     })
   })
 }
 
-Hyperlog.prototype.append = function (value, cb) {
+Hyperlog.prototype.append = function (value, opts, cb) {
+  if (typeof opts === 'function') {
+    cb = opts
+    opts = {}
+  }
   if (!cb) cb = noop
+  if (!opts) opts = {}
   var self = this
-  value = encoder.encode(value, this.valueEncoding)
+  value = encoder.encode(value, opts.valueEncoding || this.valueEncoding)
 
   this.lock(function (release) {
     self.heads(function (err, heads) {
       if (err) return release(cb, err)
       add(self, heads, value, {release: release}, function (err, node) {
         if (err) return cb(err)
-        node.value = encoder.decode(node.value, self.valueEncoding)
+        node.value = encoder.decode(node.value, opts.valueEncoding || self.valueEncoding)
         cb(null, node)
       })
     })

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -1,0 +1,18 @@
+exports.encode = function (value, enc) {
+  if (typeof enc === 'object' && enc.encode) {
+    value = enc.encode(value)
+  } else if (enc === 'json') {
+    value = Buffer(JSON.stringify(value))
+  }
+  if (typeof value === 'string') value = new Buffer(value)
+  return value
+}
+
+exports.decode = function (value, enc) {
+  if (typeof enc === 'object' && enc.decode) {
+    return enc.decode(value)
+  } else if (enc === 'json') {
+    return JSON.parse(value.toString())
+  }
+  return value
+}

--- a/test/encoding.js
+++ b/test/encoding.js
@@ -15,6 +15,43 @@ tape('add node', function (t) {
   })
 })
 
+tape('add node with encoding option', function (t) {
+  var hyper = hyperlog(memdb())
+
+  hyper.add(null, { msg: 'hello world' }, { valueEncoding: 'json' },
+  function (err, node) {
+    t.error(err)
+    t.ok(node.key, 'has key')
+    t.same(node.links, [])
+    t.same(node.value, { msg: 'hello world' })
+    t.end()
+  })
+})
+
+tape('append node', function (t) {
+  var hyper = hyperlog(memdb(), { valueEncoding: 'json' })
+
+  hyper.append({ msg: 'hello world' }, function (err, node) {
+    t.error(err)
+    t.ok(node.key, 'has key')
+    t.same(node.links, [])
+    t.same(node.value, { msg: 'hello world' })
+    t.end()
+  })
+})
+
+tape('append node with encoding option', function (t) {
+  var hyper = hyperlog(memdb())
+
+  hyper.append({ msg: 'hello world' }, { valueEncoding: 'json' }, function (err, node) {
+    t.error(err)
+    t.ok(node.key, 'has key')
+    t.same(node.links, [])
+    t.same(node.value, { msg: 'hello world' })
+    t.end()
+  })
+})
+
 tape('add node with links', function (t) {
   var hyper = hyperlog(memdb(), { valueEncoding: 'json' })
 
@@ -60,6 +97,62 @@ tape('heads', function (t) {
           })
         })
       })
+    })
+  })
+})
+
+tape('heads with encoding option', function (t) {
+  var hyper = hyperlog(memdb())
+
+  hyper.heads({ valueEncoding: 'json' }, function (err, heads) {
+    t.error(err)
+    t.same(heads, [], 'no heads yet')
+    hyper.add(null, 'a', { valueEncoding: 'json' }, function (err, node) {
+      t.error(err)
+      hyper.heads({ valueEncoding: 'json' }, function (err, heads) {
+        t.error(err)
+        t.same(heads, [node], 'has head')
+        hyper.add(node, 'b', { valueEncoding: 'json' }, function (err, node2) {
+          t.error(err)
+          hyper.heads({ valueEncoding: 'json' }, function (err, heads) {
+            t.error(err)
+            t.same(heads, [node2], 'new heads')
+            t.end()
+          })
+        })
+      })
+    })
+  })
+})
+
+tape('get', function (t) {
+  var hyper = hyperlog(memdb(), { valueEncoding: 'json' })
+
+  hyper.add(null, { msg: 'hello world' }, function (err, node) {
+    t.error(err)
+    t.ok(node.key, 'has key')
+    t.same(node.links, [])
+    t.same(node.value, { msg: 'hello world' })
+    hyper.get(node.key, function (err, node2) {
+      t.ifError(err)
+      t.same(node2.value, { msg: 'hello world' })
+      t.end()
+    })
+  })
+})
+
+tape('get with encoding option', function (t) {
+  var hyper = hyperlog(memdb())
+
+  hyper.add(null, { msg: 'hello world' }, { valueEncoding: 'json' }, function (err, node) {
+    t.error(err)
+    t.ok(node.key, 'has key')
+    t.same(node.links, [])
+    t.same(node.value, { msg: 'hello world' })
+    hyper.get(node.key, { valueEncoding: 'json' }, function (err, node2) {
+      t.ifError(err)
+      t.same(node2.value, { msg: 'hello world' })
+      t.end()
     })
   })
 })

--- a/test/encoding.js
+++ b/test/encoding.js
@@ -1,0 +1,81 @@
+var hyperlog = require('../')
+var tape = require('tape')
+var memdb = require('memdb')
+var collect = require('stream-collector')
+
+tape('add node', function (t) {
+  var hyper = hyperlog(memdb(), { valueEncoding: 'json' })
+
+  hyper.add(null, { msg: 'hello world' }, function (err, node) {
+    t.error(err)
+    t.ok(node.key, 'has key')
+    t.same(node.links, [])
+    t.same(node.value, { msg: 'hello world' })
+    t.end()
+  })
+})
+
+tape('add node with links', function (t) {
+  var hyper = hyperlog(memdb(), { valueEncoding: 'json' })
+
+  hyper.add(null, { msg: 'hello' }, function (err, node) {
+    t.error(err)
+    hyper.add(node, { msg: 'world' }, function (err, node2) {
+      t.error(err)
+      t.ok(node2.key, 'has key')
+      t.same(node2.links, [node.key], 'has links')
+      t.same(node2.value, { msg: 'world' })
+      t.end()
+    })
+  })
+})
+
+tape('cannot add node with bad links', function (t) {
+  var hyper = hyperlog(memdb(), { valueEncoding: 'json' })
+
+  hyper.add('i-do-not-exist', { msg: 'hello world' }, function (err) {
+    t.ok(err, 'had error')
+    t.ok(err.notFound, 'not found error')
+    t.end()
+  })
+})
+
+tape('heads', function (t) {
+  var hyper = hyperlog(memdb(), { valueEncoding: 'json' })
+
+  hyper.heads(function (err, heads) {
+    t.error(err)
+    t.same(heads, [], 'no heads yet')
+    hyper.add(null, 'a', function (err, node) {
+      t.error(err)
+      hyper.heads(function (err, heads) {
+        t.error(err)
+        t.same(heads, [node], 'has head')
+        hyper.add(node, 'b', function (err, node2) {
+          t.error(err)
+          hyper.heads(function (err, heads) {
+            t.error(err)
+            t.same(heads, [node2], 'new heads')
+            t.end()
+          })
+        })
+      })
+    })
+  })
+})
+
+tape('deduplicates', function (t) {
+  var hyper = hyperlog(memdb(), { valueEncoding: 'json' })
+
+  hyper.add(null, { msg: 'hello world' }, function (err, node) {
+    t.error(err)
+    hyper.add(null, { msg: 'hello world' }, function (err, node) {
+      t.error(err)
+      collect(hyper.createReadStream(), function (err, changes) {
+        t.error(err)
+        t.same(changes.length, 1, 'only one change')
+        t.end()
+      })
+    })
+  })
+})


### PR DESCRIPTION
This patch adds support for valueEncodings in both the hyperlog constructor and in various hyperlog methods, the same as it works in leveldb.

With this patch you can do:

``` js
var log = hyperlog(db, { valueEncoding: 'json' })
log.append({ msg: 'whatever' })
```

and

``` js
log.append({ msg: 'whatever' }, { valueEncoding: 'json' })
```