### PR TITLE
preadd event

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,22 @@ Options include:
 If you send `metadata` it will be emitted as an `metadata` event on the stream.
 A detailed write up on how the graph replicates will be added later.
 
+#### log.on('preadd', function (node) {})
+
+On the same tick as `log.add()` is called, this event fires with the `node`
+about to be inserted into the log. At this stage of the add process, node has
+these properties:
+
+* `node.log`
+* `node.key`
+* `node.value`
+* `node.links`
+
+#### log.on('add', function (node) {})
+
+After a node has been successfully added to the log, this event fires with the
+full `node` object that the callback to `.add()` gets.
+
 ## License
 
 MIT

--- a/test/events.js
+++ b/test/events.js
@@ -1,0 +1,39 @@
+var hyperlog = require('../')
+var tape = require('tape')
+var memdb = require('memdb')
+
+tape('add and preadd events', function (t) {
+  t.plan(12)
+  var hyper = hyperlog(memdb())
+  var expected = [ 'hello', 'world' ]
+  var expectedPre = [ 'hello', 'world' ]
+  var order = []
+
+  hyper.add(null, 'hello', function (err, node) {
+    t.error(err)
+    hyper.add(node, 'world', function (err, node2) {
+      t.error(err)
+      t.ok(node2.key, 'has key')
+      t.same(node2.links, [node.key], 'has links')
+      t.same(node2.value, new Buffer('world'))
+      t.deepEqual(order, [
+        'preadd hello',
+        'add hello',
+        'preadd world',
+        'add world'
+      ], 'order')
+    })
+  })
+  hyper.on('add', function (node) {
+    // at this point, the event has already been added
+    t.equal(node.value.toString(), expected.shift())
+    order.push('add ' + node.value)
+  })
+  hyper.on('preadd', function (node) {
+    t.equal(node.value.toString(), expectedPre.shift())
+    order.push('preadd ' + node.value)
+    hyper.get(node.key, function (err) {
+      t.ok(err.notFound)
+    })
+  })
+})


### PR DESCRIPTION
This patch adds a `'preadd'` event to compliment the existing `'add'` event.

I'm building an indexing layer for hyperlog and want to be notified on the same tick as `.add()` is called so that I can queue reads and writes until the indexes are completely caught up with the log.

This patch adds tests and documentation for both `'preadd'` and `'add'` events and adds the `node` reference as an argument in both events.