### PR TITLE
add signed node support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,25 @@ Create a new log instance. Options include:
 }
 ```
 
+You can also pass in a `identity` and a `sign` and `verify` function
+which can be used to create a signed log
+
+``` js
+{
+  identity: aPublicKeyBuffer, // will be added to all nodes you insert
+  sign: function (node, cb) {
+    // will be called with all nodes you add
+    var signatureBuffer = someCrypto.sign(node.key, mySecretKey)
+    cb(null, signatureBuffer)
+  },
+  verify: function (node, cb) {
+    // will be called with all nodes you receive
+    if (!node.signature) return cb(null, false)
+    cb(null, someCrypto.verify(node.key, node.signature. node.identity))
+  }
+}
+```
+
 #### `log.add(links, value, opts={}, [cb])`
 
 Add a new node to the graph. `links` should be an array of node keys that this node links to.

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -107,7 +107,15 @@ module.exports = function (dag, opts) {
   }
 
   var receiveNode = function (node, cb) {
-    dag.add(node.links, node.value, {hash: node.key, log: node.log, seq: node.seq, valueEncoding: 'binary'}, function (err) {
+    var opts = {
+      hash: node.key,
+      log: node.log,
+      seq: node.seq,
+      identity: node.identity,
+      signature: node.signature,
+      valueEncoding: 'binary'
+    }
+    dag.add(node.links, node.value, opts, function (err) {
       if (!err) return afterAdd(cb)
       if (!err.notFound) return cb(err)
       incoming.push(node, cb)

--- a/schema.proto
+++ b/schema.proto
@@ -1,10 +1,12 @@
 message Node {
-  required uint32 change = 1;
-  required string key    = 2;
-  required string log    = 3;
-  optional uint32 seq    = 4;
-  required bytes value   = 5;
-  repeated string links  = 6;
+  required uint32 change   = 1;
+  required string key      = 2;
+  required string log      = 3;
+  optional uint32 seq      = 4;
+  optional bytes identity  = 7;
+  optional bytes signature = 8;
+  required bytes value     = 5;
+  repeated string links    = 6;
 }
 
 message Entry {

--- a/test/signatures.js
+++ b/test/signatures.js
@@ -1,0 +1,90 @@
+var hyperlog = require('../')
+var tape = require('tape')
+var memdb = require('memdb')
+
+tape('sign', function (t) {
+  t.plan(4)
+
+  var log = hyperlog(memdb(), {
+    identity: new Buffer('i-am-a-public-key'),
+    sign: function (node, cb) {
+      t.same(node.value, new Buffer('hello'), 'sign is called')
+      cb(null, new Buffer('i-am-a-signature'))
+    }
+  })
+
+  log.add(null, 'hello', function (err, node) {
+    t.error(err, 'no err')
+    t.same(node.signature, new Buffer('i-am-a-signature'), 'has signature')
+    t.same(node.identity, new Buffer('i-am-a-public-key'), 'has public key')
+    t.end()
+  })
+})
+
+tape('sign fails', function (t) {
+  var log = hyperlog(memdb(), {
+    identity: new Buffer('i-am-a-public-key'),
+    sign: function (node, cb) {
+      cb(new Error('lol'))
+    }
+  })
+
+  log.add(null, 'hello', function (err) {
+    t.same(err && err.message, 'lol', 'had error')
+    t.end()
+  })
+})
+
+tape('verify', function (t) {
+  t.plan(3)
+
+  var log1 = hyperlog(memdb(), {
+    identity: new Buffer('i-am-a-public-key'),
+    sign: function (node, cb) {
+      cb(null, new Buffer('i-am-a-signature'))
+    }
+  })
+
+  var log2 = hyperlog(memdb(), {
+    verify: function (node, cb) {
+      t.same(node.signature, new Buffer('i-am-a-signature'), 'verify called with signature')
+      t.same(node.identity, new Buffer('i-am-a-public-key'), 'verify called with public key')
+      cb(null, true)
+    }
+  })
+
+  log1.add(null, 'hello', function (err, node) {
+    t.error(err, 'no err')
+    var stream = log2.replicate()
+    stream.pipe(log1.replicate()).pipe(stream)
+  })
+})
+
+tape('verify fails', function (t) {
+  t.plan(2)
+
+  var log1 = hyperlog(memdb(), {
+    identity: new Buffer('i-am-a-public-key'),
+    sign: function (node, cb) {
+      cb(null, new Buffer('i-am-a-signature'))
+    }
+  })
+
+  var log2 = hyperlog(memdb(), {
+    verify: function (node, cb) {
+      cb(null, false)
+    }
+  })
+
+  log1.add(null, 'hello', function (err, node) {
+    t.error(err, 'no err')
+
+    var stream = log2.replicate()
+
+    stream.on('error', function (err) {
+      t.same(err.message, 'Invalid signature', 'stream had error')
+      t.end()
+    })
+    stream.pipe(log1.replicate()).pipe(stream)
+  })
+})


### PR DESCRIPTION
adds support for signing/verifying graph nodes using the following api

``` js
var log = hyperlog(db, {
  publicKey: myPublicKeyBuffer,
  sign: function (node, cb) {
    myCrypto.sign(node.key, mySecretKey, function (err, signature) {
      cb(err, signature)
    })
  },
  verify: function (node, cb) {
    if (!node.signature || !node.publicKey) return cb(null, false) // only allow signed nodes
    myCrypto.verify(node.key, node.signature, node.publicKey, function (err, valid) {
      cb(err, valid)
    })
  }
})
```