### PR TITLE
Support tail option to createReadStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,11 @@ Options include:
 
 ``` js
 {
-  since: changeNumber     // only returns changes AFTER the number
+  since: changeNumber     // only returns changes AFTER the number  
   live: false             // never close the change stream
   tail: false             // since = lastChange
+  limit: number           // (for live  streams) only return up to `limit` changes
+  until: number           // (for non-live streams) only returns changed BEFORE the number
   valueEncoding: 'binary'
 }
 ```

--- a/index.js
+++ b/index.js
@@ -262,7 +262,7 @@ var createLiveStream = function (dag, opts) {
 Hyperlog.prototype.createReadStream = function (opts) {
   if (!opts) opts = {}
   if (opts.tail) {
-    opts.since = this.changes;
+    opts.since = this.changes
   }
   if (opts.live) return createLiveStream(this, opts)
 

--- a/index.js
+++ b/index.js
@@ -261,6 +261,9 @@ var createLiveStream = function (dag, opts) {
 
 Hyperlog.prototype.createReadStream = function (opts) {
   if (!opts) opts = {}
+  if (opts.tail) {
+    opts.since = this.changes;
+  }
   if (opts.live) return createLiveStream(this, opts)
 
   var self = this


### PR DESCRIPTION
I noticed that the `tail` option was documented but not implemented.

As an alternative to this you could just remove it from the readme guess :)

I also documented the `limit` and `until` in the readme