### PR TITLE
live replication encoding fix

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -3,6 +3,7 @@ var pump = require('pump')
 var bitfield = require('bitfield')
 var protocol = require('./protocol')
 var sortedQueue = require('./sorted-queue')
+var encoder = require('./encode.js')
 
 var noop = function () {}
 var noarr = []
@@ -62,6 +63,7 @@ module.exports = function (dag, opts) {
 
   var sendChanges = function () {
     var write = function (node, enc, cb) {
+      node.value = encoder.encode(node.value, dag.valueEncoding)
       stream.node(node, cb)
     }
 

--- a/test/encoding.js
+++ b/test/encoding.js
@@ -172,3 +172,21 @@ tape('deduplicates', function (t) {
     })
   })
 })
+
+tape('live replication encoding', function (t) {
+  t.plan(2)
+  var h0 = hyperlog(memdb(), { valueEncoding: 'json' })
+  var h1 = hyperlog(memdb(), { valueEncoding: 'json' })
+  h1.createReadStream({ live: true })
+    .on('data', function (data) {
+      t.deepEqual(data.value, { msg: 'hello world' })
+    })
+
+  var r0 = h0.replicate({ live: true })
+  var r1 = h1.replicate({ live: true })
+
+  h0.add(null, { msg: 'hello world' }, function (err, node) {
+    t.error(err)
+    r0.pipe(r1).pipe(r0)
+  })
+})


### PR DESCRIPTION
Under live replication with a valueEncoding of `json`, I was getting these errors:

```
TypeError: Argument must be a string
    at TypeError (native)
    at Buffer.write (buffer.js:598:21)
    at Object.exports.bytes.encode (/home/substack/projects/hyperlog/node_modules/protocol-buffers/encodings.js:35:17)
    at Object.encode (eval at <anonymous> (/home/substack/projects/hyperlog/node_modules/generate-function/index.js:55:21), <anonymous>:36:10)
    at Protocol._encode (/home/substack/projects/hyperlog/lib/protocol.js:102:7)
    at Protocol.node (/home/substack/projects/hyperlog/lib/protocol.js:77:8)
    at DestroyableTransform.write [as _transform] (/home/substack/projects/hyperlog/lib/replicate.js:67:14)
    at DestroyableTransform.Transform._read (/home/substack/projects/hyperlog/node_modules/readable-stream/lib/_stream_transform.js:172:10)
    at DestroyableTransform.Transform._write (/home/substack/projects/hyperlog/node_modules/readable-stream/lib/_stream_transform.js:160:12)
    at doWrite (/home/substack/projects/hyperlog/node_modules/readable-stream/lib/_stream_writable.js:335:12)
```

This patch adds a failing test for live replication under json encoding with a small fix.