### PR TITLE
Allows custom hash or async-hash for node values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,19 +48,23 @@ future. For now see the source code.
 
 ## API
 
-#### `log = hyperlog(db, [options])`
+#### `log = hyperlog(db, opts={})`
 
-Create a new log instance. Options include:
+Create a new log instance. Valid keys for `opts` include:
 
-``` js
-{
-  id: 'a-globally-unique-peer-id',
-  valueEncoding: 'a levelup-style encoding property' // example: 'json'
-}
-```
+- `id` - some (ideally globally unique) string identifier for the log.
+- `valueEncoding` - a [levelup-style](https://github.com/Level/levelup#options)
+  encoding string or object (e.g. `"json"`)
+- `hashFunction(links, value)` - a hash function that runs synchronously.
+  Defaults to a SHA-256 implementation.
+- `asyncHashFunction(links, value, cb)` - an asynchronous hash function with
+  node-style callback (`cb(err, hash)`).
+- `identity`, `sign`, `verify` - values for creating a cryptographically signed
+  feed. See below.
 
-You can also pass in a `identity` and a `sign` and `verify` function
-which can be used to create a signed log
+
+You can also pass in an `identity` and `sign`/`verify` functions which can be
+used to create a signed log:
 
 ``` js
 {

--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ Create a new log instance. Valid keys for `opts` include:
 - `id` - some (ideally globally unique) string identifier for the log.
 - `valueEncoding` - a [levelup-style](https://github.com/Level/levelup#options)
   encoding string or object (e.g. `"json"`)
-- `hashFunction(links, value)` - a hash function that runs synchronously.
-  Defaults to a SHA-256 implementation.
-- `asyncHashFunction(links, value, cb)` - an asynchronous hash function with
-  node-style callback (`cb(err, hash)`).
+- `hash(links, value)` - a hash function that runs synchronously. Defaults to a
+  SHA-256 implementation.
+- `asyncHash(links, value, cb)` - an asynchronous hash function with node-style
+  callback (`cb(err, hash)`).
 - `identity`, `sign`, `verify` - values for creating a cryptographically signed
   feed. See below.
 

--- a/index.js
+++ b/index.js
@@ -47,8 +47,8 @@ var Hyperlog = function (db, opts) {
   this.identity = defined(opts.identity, null)
   this.verify = defined(opts.verify, null)
   this.sign = defined(opts.sign, null)
-  this.hashFunction = defined(opts.hashFunction, hash)
-  this.asyncHashFunction = defined(opts.asyncHashFunction, null)
+  this.hash = defined(opts.hash, hash)
+  this.asyncHash = defined(opts.asyncHash, null)
 
   var self = this
   var getId = defined(opts.getId, function (cb) {
@@ -303,18 +303,15 @@ Hyperlog.prototype.add = function (links, value, opts, cb) {
 
   var encodedValue = encoder.encode(value, opts.valueEncoding || self.valueEncoding)
 
-  if (this.asyncHashFunction) {
-    this.asyncHashFunction(links, encodedValue, postHashing)
+  if (this.asyncHash) {
+    this.asyncHash(links, encodedValue, postHashing)
   } else {
-    var key = this.hashFunction(links, encodedValue)
+    var key = this.hash(links, encodedValue)
     postHashing(null, key)
   }
 
   function postHashing (err, key) {
-    if (err) {
-      cb(err)
-      return
-    }
+    if (err) return cb(err)
 
     self.ready(function () {
       add(self, links, encodedValue, key, opts, function (err, node) {

--- a/index.js
+++ b/index.js
@@ -321,11 +321,8 @@ Hyperlog.prototype.append = function (value, opts, cb) {
   this.lock(function (release) {
     self.heads(function (err, heads) {
       if (err) return release(cb, err)
-      add(self, heads, value, {release: release}, function (err, node) {
-        if (err) return cb(err)
-        node.value = encoder.decode(node.value, opts.valueEncoding || self.valueEncoding)
-        cb(null, node)
-      })
+      opts.release = release
+      self.add(heads, value, opts, cb)
     })
   })
 }

--- a/package.json
+++ b/package.json
@@ -24,8 +24,10 @@
     "through2": "^2.0.0"
   },
   "devDependencies": {
+    "bs58": "^3.0.0",
     "memdb": "^1.0.1",
     "standard": "^5.0.0",
+    "multihashing": "^0.2.0",
     "tape": "^4.0.0"
   },
   "browserify": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "brfs": "^1.4.0",
     "cuid": "^1.2.5",
     "debug": "^2.2.0",
+    "defined": "^1.0.0",
     "duplexify": "^3.4.2",
     "framed-hash": "^1.1.0",
     "from2": "^2.1.0",

--- a/test/hash.js
+++ b/test/hash.js
@@ -23,7 +23,7 @@ var asyncSha2 = function (links, value, cb) {
 
 tape('add node using sha1', function (t) {
   var hyper = hyperlog(memdb(), {
-    hashFunction: sha1
+    hash: sha1
   })
 
   hyper.add(null, 'hello world', function (err, node) {
@@ -35,7 +35,7 @@ tape('add node using sha1', function (t) {
 
 tape('add node with links using sha1', function (t) {
   var hyper = hyperlog(memdb(), {
-    hashFunction: sha1
+    hash: sha1
   })
 
   hyper.add(null, 'hello', function (err, node) {
@@ -51,7 +51,7 @@ tape('add node with links using sha1', function (t) {
 
 tape('add node using async multihash', function (t) {
   var hyper = hyperlog(memdb(), {
-    asyncHashFunction: asyncSha2
+    asyncHash: asyncSha2
   })
 
   hyper.add(null, 'hello world', function (err, node) {
@@ -63,7 +63,7 @@ tape('add node using async multihash', function (t) {
 
 tape('add node with links using async multihash', function (t) {
   var hyper = hyperlog(memdb(), {
-    asyncHashFunction: asyncSha2
+    asyncHash: asyncSha2
   })
 
   hyper.add(null, 'hello', function (err, node) {

--- a/test/hash.js
+++ b/test/hash.js
@@ -1,0 +1,82 @@
+var hyperlog = require('../')
+var tape = require('tape')
+var memdb = require('memdb')
+var framedHash = require('framed-hash')
+var multihashing = require('multihashing')
+var base58 = require('bs58')
+
+var sha1 = function (links, value) {
+  var hash = framedHash('sha1')
+  for (var i = 0; i < links.length; i++) hash.update(links[i])
+  hash.update(value)
+  return hash.digest('hex')
+}
+
+var asyncSha2 = function (links, value, cb) {
+  process.nextTick(function () {
+    var prevalue = value.toString()
+    links.forEach(function (link) { prevalue += link })
+    var result = base58.encode(multihashing(prevalue, 'sha2-256'))
+    cb(null, result)
+  })
+}
+
+tape('add node using sha1', function (t) {
+  var hyper = hyperlog(memdb(), {
+    hashFunction: sha1
+  })
+
+  hyper.add(null, 'hello world', function (err, node) {
+    t.error(err)
+    t.same(node.key, '99cf70777a24b574b8fb5b3173cd4073f02098b0')
+    t.end()
+  })
+})
+
+tape('add node with links using sha1', function (t) {
+  var hyper = hyperlog(memdb(), {
+    hashFunction: sha1
+  })
+
+  hyper.add(null, 'hello', function (err, node) {
+    t.error(err)
+    t.same(node.key, '445198669b880239a7e64247ed303066b398678b')
+    hyper.add(node, 'world', function (err, node2) {
+      t.error(err)
+      t.same(node2.key, '1d95837842db3995fb3e77ed070457eb4f9875bc')
+      t.end()
+    })
+  })
+})
+
+tape('add node using async multihash', function (t) {
+  var hyper = hyperlog(memdb(), {
+    asyncHashFunction: asyncSha2
+  })
+
+  hyper.add(null, 'hello world', function (err, node) {
+    t.error(err)
+    t.same(node.key, 'QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L4')
+    t.end()
+  })
+})
+
+tape('add node with links using async multihash', function (t) {
+  var hyper = hyperlog(memdb(), {
+    asyncHashFunction: asyncSha2
+  })
+
+  hyper.add(null, 'hello', function (err, node) {
+    t.error(err)
+    t.same(node.key, 'QmRN6wdp1S2A5EtjW9A3M1vKSBuQQGcgvuhoMUoEz4iiT5')
+    hyper.add(node, 'world', function (err, node2) {
+      t.error(err)
+      t.same(node2.key, 'QmVeZeqV6sbzeDyzhxFHwBLddaQzUELCxLjrQVzfBuDrt8')
+      hyper.add([node, node2], '!!!', function (err, node3) {
+        t.error(err)
+        t.same(node3.key, 'QmNs89mwydjboQGpvcK2F3hyKjSmdqQTqDWmRMsAQnL4ZU')
+        t.end()
+      })
+    })
+  })
+})


### PR DESCRIPTION
This exposes `hashFunction` and `asyncHashFunction` in `opts`, which defaults
to the original synchronous sha256 scheme.

I've also collapsed most of `hyperlog#append`'s logic into `hyperlog#add`.

There are tests. :horse: