### PR TITLE
reject event so there is a corresponding event for every preadd

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,13 @@ these properties:
 After a node has been successfully added to the log, this event fires with the
 full `node` object that the callback to `.add()` gets.
 
+#### log.on('reject', function (node) {})
+
+When a node is rejected, this event fires. Otherwise the `add` event will fire.
+
+You can track `preadd` events against both `add` and `reject` events in
+combination to know when the log is completely caught up.
+
 ## License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -308,7 +308,10 @@ Hyperlog.prototype.batch = function (docs, opts, cb) {
       if (!node.log) node.log = self.id
 
       addBatch(self, node, opts, function (err, node, nbatch) {
-        if (err) return release(cb, err)
+        if (err) {
+          self.emit('reject', node)
+          return release(cb, err)
+        }
         node.value = encoder.decode(node.value, opts.valueEncoding || self.valueEncoding)
         nodes[index] = node
         batch.push.apply(batch, nbatch)


### PR DESCRIPTION
In hyperlog-index, I'm using `preadd` and `add` events to know when the indexes are caught up with the latest document known to hyperlog. With this patch, there is always a corresponding event, either `add` or `reject` for every `preadd` event to enable keeping an external counter around.