### PR TITLE
Ensure deduped nodes have seq/change set

### DIFF
--- a/index.js
+++ b/index.js
@@ -320,12 +320,17 @@ Hyperlog.prototype.batch = function (docs, opts, cb) {
     var added = nodes.length > 1 ? {} : null
 
     nodes.forEach(function (node, index) {
-      if (added && added[node.key]) return
+      if (added && added[node.key]) {
+        node.seq = added[node.key].seq
+        node.change = added[node.key].change
+        if (!node.log) node.log = self.id
+        return
+      }
 
       var done = next()
       var lns = logLinks[index]
 
-      if (added) added[node.key] = true
+      if (added) added[node.key] = node
 
       node.seq = seq + 1 + index
       node.change = self.changes + 1 + index

--- a/test/basic.js
+++ b/test/basic.js
@@ -90,6 +90,7 @@ tape('deduplicates -- same batch', function (t) {
     collect(hyper.createReadStream(), function (err, changes) {
       t.error(err)
       t.same(changes.length, 1, 'only one change')
+      t.same(hyper.changes, 1, 'only one change')
       t.end()
     })
   })


### PR DESCRIPTION
I noticed that in https://github.com/mafintosh/hyperlog/commit/b1e6ed856e753767a9e2b87d778bba6032c2a658 we still include the deduped nodes, which means `node.change` will be `undefined` and the log's own `change` value then becomes `undefined`, potentially causing weird behaviour.