### PR TITLE
Ensure 'change' is correct after batch-insert.

### DIFF
--- a/index.js
+++ b/index.js
@@ -310,11 +310,7 @@ Hyperlog.prototype.batch = function (docs, opts, cb) {
       self.db.batch(batch, function (err) {
         if (err) return release(cb, err)
 
-        // find the largest change value from the batch (unless it's already
-        // the largest)
-        self.changes = nodes.reduce(function (max, cur) {
-          return Math.max(max, cur.change)
-        }, self.changes)
+        self.changes = getMaxNodeChangeValue(nodes, self.changes)
 
         for (var i = 0; i < nodes.length; i++) self.emit('add', nodes[i])
 
@@ -410,6 +406,14 @@ Hyperlog.prototype.append = function (value, opts, cb) {
       self.add(heads, value, opts, cb)
     })
   })
+}
+
+// Returns the highest change #, given an array of nodes and a current change
+// #.
+function getMaxNodeChangeValue (nodes, highest) {
+  return nodes.reduce(function (max, cur) {
+    return Math.max(max, cur.change)
+  }, highest)
 }
 
 module.exports = Hyperlog

--- a/index.js
+++ b/index.js
@@ -310,7 +310,12 @@ Hyperlog.prototype.batch = function (docs, opts, cb) {
       self.db.batch(batch, function (err) {
         if (err) return release(cb, err)
 
-        self.changes = nodes[nodes.length - 1].change
+        // find the largest change value from the batch (unless it's already
+        // the largest)
+        self.changes = nodes.reduce(function (max, cur) {
+          return Math.max(max, cur.change)
+        }, self.changes)
+
         for (var i = 0; i < nodes.length; i++) self.emit('add', nodes[i])
 
         release(cb, null, nodes)

--- a/test/batch.js
+++ b/test/batch.js
@@ -33,3 +33,23 @@ tape('batch', function (t) {
     })
   })
 })
+
+tape('batch dedupe', function (t) {
+  t.plan(4)
+
+  var doc1 = { links: [], value: 'hello world' }
+  var doc2 = { links: [], value: 'hello world 2' }
+
+  var hyper = hyperlog(memdb(), { valueEncoding: 'utf8' })
+
+  hyper.batch([doc1], function (err) {
+    t.error(err)
+    hyper.batch([doc2], function (err) {
+      t.error(err)
+      hyper.batch([doc1], function (err) {
+        t.error(err)
+        t.equal(hyper.changes, 2)
+      })
+    })
+  })
+})


### PR DESCRIPTION
When a document that already exists in the dag is inserted, it is
deduplicated. However, since the exising node's `change` value will be smaller
than the current head of the log, there needs to be a bit of extra logic to
ensure that `change` only ever increases. In this case, the formula is

```js
changes = Math.max(changes, biggest_change_value_in_what_was_just_batch_inserted)
```