### PR TITLE
fixes for per-document identity and opts.identity

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,7 +184,7 @@ var addBatch = function (dag, node, logLinks, batch, opts, cb) {
     if (!dag.sign || node.signature) return done()
     dag.sign(node, function (err, sig) {
       if (err) return cb(err)
-      node.identity = dag.identity
+      if (!node.identity) node.identity = dag.identity
       node.signature = sig
       done()
     })
@@ -436,7 +436,7 @@ Hyperlog.prototype.batch = function (docs, opts, cb) {
     var node = {
       log: opts.log || self.id,
       key: null,
-      identity: opts.identity || null,
+      identity: doc.identity || opts.identity || null,
       signature: opts.signature || null,
       value: encodedValue,
       links: links

--- a/test/signatures.js
+++ b/test/signatures.js
@@ -88,3 +88,62 @@ tape('verify fails', function (t) {
     stream.pipe(log1.replicate()).pipe(stream)
   })
 })
+
+tape('per-document identity (add)', function (t) {
+  t.plan(3)
+
+  var log1 = hyperlog(memdb(), {
+    sign: function (node, cb) {
+      cb(null, new Buffer('i-am-a-signature'))
+    }
+  })
+
+  var log2 = hyperlog(memdb(), {
+    verify: function (node, cb) {
+      t.same(node.signature, new Buffer('i-am-a-signature'), 'verify called with signature')
+      t.same(node.identity, new Buffer('i-am-a-public-key'), 'verify called with public key')
+      cb(null, true)
+    }
+  })
+
+  var opts = { identity: new Buffer('i-am-a-public-key') }
+  log1.add(null, 'hello', opts, function (err, node) {
+    t.error(err, 'no err')
+    var stream = log2.replicate()
+    stream.pipe(log1.replicate()).pipe(stream)
+  })
+})
+
+tape('per-document identity (batch)', function (t) {
+  t.plan(5)
+
+  var log1 = hyperlog(memdb(), {
+    sign: function (node, cb) {
+      cb(null, new Buffer('i-am-a-signature'))
+    }
+  })
+
+  var expectedpk = [ Buffer('hello id'), Buffer('whatever id') ]
+  var log2 = hyperlog(memdb(), {
+    verify: function (node, cb) {
+      t.same(node.signature, new Buffer('i-am-a-signature'), 'verify called with signature')
+      t.same(node.identity, expectedpk.shift(), 'verify called with public key')
+      cb(null, true)
+    }
+  })
+
+  log1.batch([
+    {
+      value: 'hello',
+      identity: Buffer('hello id')
+    },
+    {
+      value: 'whatever',
+      identity: Buffer('whatever id')
+    }
+  ], function (err, nodes) {
+    t.error(err, 'no err')
+    var stream = log2.replicate()
+    stream.pipe(log1.replicate()).pipe(stream)
+  })
+})


### PR DESCRIPTION
You can set an `opts.identity` in add(), append(), and batch(), but this per-operation identity is overwritten without this patch. Also with this patch you can have per-document identities in a batch() instead of using a single identity with `opts.identity` for the whole batch.

With this patch, people will have more control over different identity schemes where multiple signing keys might be used on the same long, threaded through different operations.