### PR TITLE
Include 'node' on 'reject' events.

### DIFF
--- a/index.js
+++ b/index.js
@@ -393,13 +393,13 @@ Hyperlog.prototype.batch = function (docs, opts, cb) {
           if (added) added[node.key] = node
 
           // Create a new leveldb batch operation for this node.
-          addBatch(self, node, lns, batch, opts, function (err, node) {
+          addBatch(self, node, lns, batch, opts, function (err, newNode) {
             if (err) {
               self.emit('reject', node)
               return fin(err)
             }
-            node.value = encoder.decode(node.value, opts.valueEncoding || self.valueEncoding)
-            nodes[index] = node
+            newNode.value = encoder.decode(newNode.value, opts.valueEncoding || self.valueEncoding)
+            nodes[index] = newNode
             fin()
           })
         })

--- a/test/signatures.js
+++ b/test/signatures.js
@@ -22,6 +22,8 @@ tape('sign', function (t) {
 })
 
 tape('sign fails', function (t) {
+  t.plan(2)
+
   var log = hyperlog(memdb(), {
     identity: new Buffer('i-am-a-public-key'),
     sign: function (node, cb) {
@@ -29,9 +31,12 @@ tape('sign fails', function (t) {
     }
   })
 
+  log.on('reject', function (node) {
+    t.ok(node)
+  })
+
   log.add(null, 'hello', function (err) {
     t.same(err && err.message, 'lol', 'had error')
-    t.end()
   })
 })
 


### PR DESCRIPTION
This brings the code in line with the API, which says that `node` ought to be
included in the 'reject' event callback.

Does this feel weird? Technically the node doesn't exist in the hyperlog, so
returning it back to the user might not really make sense. I'm also happy to
just edit the API to explicitly say that no params are included in the 'reject'
event.

cc @mafintosh