### PR TITLE
Bugfix: bad links prevent 'reject' from firing

### DIFF
--- a/index.js
+++ b/index.js
@@ -422,7 +422,10 @@ Hyperlog.prototype.batch = function (docs, opts, cb) {
 
       node.key = key
       getLinks(self, id, links, function (err, lns) {
-        if (err) return done(err)
+        if (err) {
+          self.emit('reject', node)
+          return done(err)
+        }
         logLinks[index] = lns
         done()
       })

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -1,4 +1,5 @@
 var protobuf = require('protocol-buffers')
 var fs = require('fs')
+var path = require('path')
 
-module.exports = protobuf(fs.readFileSync(__dirname + '/../schema.proto', 'utf-8'))
+module.exports = protobuf(fs.readFileSync(path.join(__dirname, '..', 'schema.proto'), 'utf-8'))

--- a/test/basic.js
+++ b/test/basic.js
@@ -95,3 +95,19 @@ tape('deduplicates -- same batch', function (t) {
     })
   })
 })
+
+tape('bug repro: bad insert links results in correct preadd/add/reject counts', function (t) {
+  var hyper = hyperlog(memdb())
+
+  var pending = 0
+  hyper.on('preadd', function (node) { pending++ })
+  hyper.on('add', function (node) { pending-- })
+  hyper.on('reject', function (node) { pending-- })
+
+  hyper.add(['123'], 'hello', function (err, node) {
+    t.ok(err)
+
+    t.equal(pending, 0)
+    t.end()
+  })
+})


### PR DESCRIPTION
I found this by working backwards from a real mapeo-desktop dataset where
hyperlog-index's "ready()" never fired.

Turns out a failure from getLinks() would prevent a 'reject' event from firing,
keeping the preadd vs add/reject event count from balancing, which
hyperlog-index relies on.

Includes bugfix and a regression test.